### PR TITLE
Simpler unifiers for equations with fewer variables on one of the sides

### DIFF
--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar, showBool, TRUE, isVar} from "./Bools.js";
+import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar, showBool, TRUE} from "./Bools.js";
 import {applySubst} from "./Substitution";
 
 /**

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -39,8 +39,8 @@ export function boolUnify(f1, f2) {
     let fvsF1 = boolFreeVars(f1)
     let fvsF2 = boolFreeVars(f2)
     let fvs = fvsF2.length == 1
-        ? [...fvsF2,...fvsF1]
-        : [...fvsF1,...fvsF2]
+        ? [...fvsF2,...fvsF1.filter(v => !fvsF2.includes(v))]
+        : [...fvsF1,...fvsF2.filter(v => !fvsF1.includes(v))]
 
     try {
         let subst = successiveVariableElimination(query, fvs)

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -31,14 +31,14 @@ export function boolUnify(f1, f2) {
     let query = mkOr(mkAnd(f1, mkNot(f2)), mkAnd(mkNot(f1), f2))
 
     // The free variables in the query.
-    // Idea by Jaco van de Pol: We check to see if one
-    // side of the equation has a single variable here, and put
-    // it first in the list of free variables, so that SVE will
-    // eliminate one side first. SVE will generate a smaller, more
-    // intuitive MGU as a result.
+    // Generalization of an idea by Jaco van de Pol: We check to see
+    // if one side of the equation has fewer free variables, and put
+    // those first in the list of free variables, so that SVE will
+    // eliminate the smaller side first. SVE will generate a smaller,
+    // more intuitive MGU as a result.
     let fvsF1 = boolFreeVars(f1)
     let fvsF2 = boolFreeVars(f2)
-    let fvs = fvsF2.length == 1
+    let fvs = fvsF2.length < fvsF1.length
         ? [...fvsF2,...fvsF1.filter(v => !fvsF2.includes(v))]
         : [...fvsF1,...fvsF2.filter(v => !fvsF1.includes(v))]
 

--- a/src/Bools.js
+++ b/src/Bools.js
@@ -499,7 +499,7 @@ function lookup(f) {
             return TRUE
         }
 
-        let resultId = resultVector.map(truthElemString)
+        let resultId = resultVector.map(truthElemString).join("")
 
         // Look it up in the table.
         let minimal = MinTable[resultId]

--- a/src/Bools.js
+++ b/src/Bools.js
@@ -109,7 +109,7 @@ export function mkNot(f) {
 /**
  * Returns the conjunction of the two formulas `f1` and `f2`.
  */
-export function mkAnd(f1, f2) {
+ export function mkAnd(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
     if (f2 === undefined || !isBool(f2)) throw new Error(`Illegal argument 'f2': ${f2}.`)
 
@@ -123,13 +123,19 @@ export function mkAnd(f1, f2) {
         return FALSE
     } else if (isSyntacticEq(f1, f2)) {
         return f1
+    } else if (isComplement(f1, f2)) {
+        return FALSE
+    } else if (isAndAbsorption(f1, f2)) {
+        return f1
+    } else if (isAndAbsorption(f2, f1)) {
+        return f2
     }
 
     return {type: 'AND', f1: f1, f2: f2}
 }
 
 /**
- * Returns the disjunction of the two formulas `f1` and `f2`.
+ * Returns the inclusive disjunction of the two formulas `f1` and `f2`.
  */
 export function mkOr(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
@@ -145,9 +151,39 @@ export function mkOr(f1, f2) {
         return f1
     } else if (isSyntacticEq(f1, f2)) {
         return f1
+    } else if (isComplement(f1, f2)) {
+        return TRUE
+    } else if (isOrAbsorption(f1, f2)) {
+        return f1
+    } else if (isOrAbsorption(f2, f1)) {
+        return f2
     }
 
     return {type: 'OR', f1: f1, f2: f2}
+}
+
+/**
+ * Returns `true` if `f1` is the syntactic complement of `f2`.
+ */
+function isComplement(f1, f2) {
+    return (isNot(f2) && isSyntacticEq(f1, f2.f))
+        || (isNot(f1) && isSyntacticEq(f2, f1.f))
+}
+
+/**
+ * Returns `true` if `f` is a syntactic component of `absorb`,
+ * e.g. `f && (? || f) = true` or `f && (f || ?) = true`
+ */
+ function isAndAbsorption(f, absorb) {
+    return isOr(absorb) && (isSyntacticEq(f, absorb.f2) || isSyntacticEq(f, absorb.f1))
+}
+
+/**
+ * Returns `true` if `f` is a syntactic component of `absorb`,
+ * e.g. `f || (? && f) = true` or `f || (f && ?) = true`
+ */
+function isOrAbsorption(f, absorb) {
+    return isAnd(absorb) && (isSyntacticEq(f, absorb.f2) || isSyntacticEq(f, absorb.f1))
 }
 
 /**

--- a/src/Bools.js
+++ b/src/Bools.js
@@ -109,7 +109,7 @@ export function mkNot(f) {
 /**
  * Returns the conjunction of the two formulas `f1` and `f2`.
  */
- export function mkAnd(f1, f2) {
+export function mkAnd(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
     if (f2 === undefined || !isBool(f2)) throw new Error(`Illegal argument 'f2': ${f2}.`)
 
@@ -135,7 +135,7 @@ export function mkNot(f) {
 }
 
 /**
- * Returns the inclusive disjunction of the two formulas `f1` and `f2`.
+ * Returns the disjunction of the two formulas `f1` and `f2`.
  */
 export function mkOr(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)


### PR DESCRIPTION
Fixes #1

**Goal**

Boolean unification does not have unique MGUs, but should prefer to generate minimized and 'easy to understand' unifiers when possible. Boolean minimization techniques help in many scenarios, but there is no one technique that outperforms others in all cases. The change proposed by this PR handles a small but important special case: when one side of an equation is just a variable not contained in the other side of the equation.

**Results**

Without special case:
```
a = b || c || d || f || e
    yields [a --> ((b ∨ (c ∨ (d ∨ f))) ∨ e) ∨ (a ∧ ((b ∨ (c ∨ (d ∨ f))) ∨ e)); b --> b; ...]
c = a || b || d || f || e
    yields [
        a --> (((c ∨ (d ∨ (e ∨ f))) ∧ ¬((((b ∧ (c ∨ (d ∨ (e ∨ f)))) ∨ d) ∨ f) ∨ e)) ∨ ((¬c ∧ (¬d ∧ (¬e ∧ ¬f))) ∧ ((((b ∧ (c ∨ (d ∨ (e ∨ f)))) ∨ d) ∨ f) ∨ e))) ∨ (a ∧ (c ∨ (d ∨ (e ∨ f))));
        b --> b ∧ (c ∨ (d ∨ (e ∨ f)));
        c --> c ∨ (d ∨ (e ∨ f));
        d --> d;
        ...]
c = a || b || d
    yields [a --> (c ∨ d) ∧ (a ∨ (¬b ∧ ¬d)); b --> b ∧ (c ∨ d); c --> c ∨ d; d --> d]
```

With special case:
```
a = b || c || d || f || e
    yields [a --> ((b ∨ (c ∨ d)) ∨ e) ∨ f]
c = a || b || d || f || e
    yields [c --> ((a ∨ (b ∨ d)) ∨ f) ∨ e]
c = a || b || d
    yields [c --> a ∨ (b ∨ d)]
```

**Partial proof sketch**

*Conjecture*: Given a Boolean equation `X = Eqn`, where the variable `X` is not free in `Eqn`, then `[X --> Eqn]` is a valid MGU for `X = Eqn`.

Let `X` be a Boolean variable, `Eqn` a Boolean equation in which `X` is not free, and let `S` be the substitution `[X --> Eqn]`. Given that `X` is not free in `Eqn`, we know that applying `S` to `Eqn` will have no effect. Applying `S` to `X` will yield `Eqn`, and so applying `S` to `X = Eqn` will yield `Eqn = Eqn`, a syntactic equality of Boolean equations.

**Possibilities**

It is possible that the special case is applied too conservatively. Currently, given `X = Eqn`, the special case is only applied if `X ∉ free(Eqn)`. Maybe there is a similar special case that applies when `X ∈ free(Eqn)`, however the presence of negations of `X` in `Eqn` make the case more complicated.