### PR TITLE
Add option to use Lowenheim's method on the workbench

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,23 @@
+# Learn more about this file at https://www.gitpod.io/docs/references/gitpod-yml
+tasks:
+  - init: yarn
+    command: yarn start
+ports:
+  - port: 3000
+    onOpen: open-preview
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,4 @@
 By adding your name to this document, you agree to release all your contributions to Flix under the [Apache 2.0 License](LICENSE.md).
 
 - [Magnus Madsen](https://github.com/magnus-madsen)
+- [Rob Kleffner](https://github.com/robertkleffner)

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ import {unifyTerm} from "./TermUnification";
 import {applySubst} from "./Substitution";
 import {termFreeVars} from "./Terms";
 import Footer from "./components/Footer";
-import { boolUnify, lowenheimUnify } from './BoolUnification';
+import { getUnifyMethod, METHOD } from './BoolUnification';
 
 class App extends Component {
 
@@ -43,7 +43,7 @@ class App extends Component {
             minimizeSubFormulas: true,
             truthTable: false,
             parenthesize: false,
-            lowenheim: false,
+            unifyMethod: METHOD.SVE
         }
     }
 
@@ -53,8 +53,8 @@ class App extends Component {
         console.log("Solve y = ", y)
 
         // Compute the mgu.
-        let bUnify = this.state.lowenheim ? lowenheimUnify : boolUnify;
-        console.log(`Using Lowenheim: ${this.state.lowenheim}`)
+        console.log(`Using Boolean unification method: ${this.state.unifyMethod}`)
+        let bUnify = getUnifyMethod(this.state.unifyMethod)
         let result = unifyTerm(x, y, bUnify)
 
         // Check if it exists.
@@ -109,8 +109,8 @@ class App extends Component {
         this.setState({parenthesize: !this.state.parenthesize})
     }
 
-    toggleLowenheim(after) {
-        this.setState({lowenheim: !this.state.lowenheim}, after)
+    changeMethod(method, after) {
+        this.setState({unifyMethod: method}, after)
     }
 
     render() {
@@ -137,8 +137,8 @@ class App extends Component {
                     parenthesize={this.state.parenthesize}
                     toggleParenthesize={this.toggleParenthesize.bind(this)}
 
-                    lowenheim={this.state.lowenheim}
-                    toggleLowenheim={this.toggleLowenheim.bind(this)}
+                    unifyMethod={this.state.unifyMethod}
+                    changeMethod={this.changeMethod.bind(this)}
 
                     notifySolve={this.notifySolve.bind(this)}
                     notifyClear={this.notifyClear.bind(this)}

--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import {unifyTerm} from "./TermUnification";
 import {applySubst} from "./Substitution";
 import {termFreeVars} from "./Terms";
 import Footer from "./components/Footer";
+import { boolUnify, lowenheimUnify } from './BoolUnification';
 
 class App extends Component {
 
@@ -42,6 +43,7 @@ class App extends Component {
             minimizeSubFormulas: true,
             truthTable: false,
             parenthesize: false,
+            lowenheim: false,
         }
     }
 
@@ -51,7 +53,9 @@ class App extends Component {
         console.log("Solve y = ", y)
 
         // Compute the mgu.
-        let result = unifyTerm(x, y)
+        let bUnify = this.state.lowenheim ? lowenheimUnify : boolUnify;
+        console.log(`Using Lowenheim: ${this.state.lowenheim}`)
+        let result = unifyTerm(x, y, bUnify)
 
         // Check if it exists.
         if (result.status === "success") {
@@ -105,6 +109,10 @@ class App extends Component {
         this.setState({parenthesize: !this.state.parenthesize})
     }
 
+    toggleLowenheim(after) {
+        this.setState({lowenheim: !this.state.lowenheim}, after)
+    }
+
     render() {
         return (
             <Container>
@@ -128,6 +136,9 @@ class App extends Component {
 
                     parenthesize={this.state.parenthesize}
                     toggleParenthesize={this.toggleParenthesize.bind(this)}
+
+                    lowenheim={this.state.lowenheim}
+                    toggleLowenheim={this.toggleLowenheim.bind(this)}
 
                     notifySolve={this.notifySolve.bind(this)}
                     notifyClear={this.notifyClear.bind(this)}

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -156,7 +156,6 @@ export function lowenheimUnify(f1, f2) {
     }
 
     for (const [ind, mgu] of mgus.entries()) {
-        console.log(`MGU #${ind} with ${Object.keys(mgu).length} keys`)
         for (const [key, val] of Object.entries(mgu)) {
             console.log(`  ${key} --> ${showBool(minBool(val, true))}`)
         }

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -46,17 +46,6 @@ export function boolUnify(f1, f2) {
         throw new Error(`Illegal argument 'y': ${f2}.`)
     }
 
-    // Special case for when one side of the equation is a variable. This will generate a
-    // 'simpler' substitution than SVE, especially when the equation side has lots of variables.
-    if (isSingleVarSpecialCase(f1, f2)) {
-        let subst = {[f1.name]: f2}
-        return {status: "success", subst: subst}
-    }
-    if (isSingleVarSpecialCase(f2, f1)) {
-        let subst = {[f2.name]: f1}
-        return {status: "success", subst: subst}
-    }
-
     // The boolean expression we want to show is 0.
     let query = mkOr(mkAnd(f1, mkNot(f2)), mkAnd(mkNot(f1), f2))
 
@@ -145,13 +134,6 @@ function satisfiable(f) {
     } else {
         throw new Error(`Illegal argument 'f': ${f}.`)
     }
-}
-
-/**
- * Check whether an equation is of the form `Var(X) =? Equation`, where X not in free(Equation).
- */
-function isSingleVarSpecialCase(maybeVar, maybeAssigned) {
-    return isVar(maybeVar) && !boolFreeVars(maybeAssigned).includes(maybeVar.name);
 }
 
 export function lowenheimUnify(f1, f2) {

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar, showBool, TRUE, isVar, isAnd, isSyntacticEq, isOr, isNot} from "./Bools.js";
+import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar, showBool, TRUE, isVar} from "./Bools.js";
 import {applySubst} from "./Substitution";
 
 /**
@@ -27,23 +27,15 @@ export function boolUnify(f1, f2) {
         throw new Error(`Illegal argument 'y': ${f2}.`)
     }
 
-    // Special case for when
-    // 1. free(f1) ∩ free(f2) == {}
-    // 2. f1 matches f2 or f2 matches f1
-    // This will generate 'simpler' substitutions than SVE,
-    // especially when the equations have lots of variables.
-    let f1Free = boolFreeVars(f1);
-    let f2Free = boolFreeVars(f2);
-    let freeOverlap = [...f1Free].filter(x => f2Free.includes(x))
-    if (freeOverlap.length == 0) {
-        try {
-            let subst = syntacticMatch(f1, f2)
-            return {status: "success", subst: subst}
-        } catch (e) { }
-        try {
-            let subst = syntacticMatch(f2, f1)
-            return {status: "success", subst: subst}
-        } catch (e) { }
+    // Special case for when one side of the equation is a variable. This will generate a
+    // 'simpler' substitution than SVE, especially when the equation side has lots of variables.
+    if (isSingleVarSpecialCase(f1, f2)) {
+        let subst = {[f1.name]: f2}
+        return {status: "success", subst: subst}
+    }
+    if (isSingleVarSpecialCase(f2, f1)) {
+        let subst = {[f2.name]: f1}
+        return {status: "success", subst: subst}
     }
 
     // The boolean expression we want to show is 0.
@@ -96,7 +88,7 @@ function successiveVariableElimination(f, fvs) {
  *
  * That is, always retains all the bindings in `subst1`.
  */
-function leftMerge(subst1, subst2, overlapMustMatch = false) {
+function leftMerge(subst1, subst2) {
     if (typeof subst1 !== "object") {
         throw new Error(`Illegal argument 'subst1': ${subst1}.`)
     }
@@ -113,8 +105,6 @@ function leftMerge(subst1, subst2, overlapMustMatch = false) {
         // Left-biased. Only add if not present in subst1.
         if (subst1[key] === undefined) {
             result[key] = value
-        } else if (overlapMustMatch && !isSyntacticEq(subst1[key], value)) {
-            throw new SyntacticMatchError(`Variable ${key} matched two different values ${subst1[key]} and ${value}`)
         }
     }
 
@@ -139,27 +129,10 @@ function satisfiable(f) {
 }
 
 /**
- * Generates a substitution that makes subst(template) = inst, if one can
- * be generated. Throws a SyntacticMatchError if a substitution cannot be
- * generated.
+ * Check whether an equation is of the form `Var(X) =? Equation`, where X not in free(Equation).
  */
-function syntacticMatch(template, inst) {
-    if (isSyntacticEq(template, inst)) {
-        return {}
-    } else if (isVar(template)) {
-        return {[template.name]: inst}
-    } else if (isAnd(template) && isAnd(inst)) {
-        let leftSubst = syntacticMatch(template.f1, inst.f1)
-        let rightSubst = syntacticMatch(template.f2, inst.f2)
-        return leftMerge(leftSubst, rightSubst, true)
-    } else if (isOr(template) && isOr(inst)) {
-        let leftSubst = syntacticMatch(template.f1, inst.f1)
-        let rightSubst = syntacticMatch(template.f2, inst.f2)
-        return leftMerge(leftSubst, rightSubst, true)
-    } else if (isNot(template) && isNot(inst)) {
-        return syntacticMatch(template.f, inst.f)
-    }
-    throw new SyntacticMatchError(`Couldn't match '${template}' with '${inst}`)
+function isSingleVarSpecialCase(maybeVar, maybeAssigned) {
+    return isVar(maybeVar) && !boolFreeVars(maybeAssigned).includes(maybeVar.name);
 }
 
 /**
@@ -169,15 +142,5 @@ class SVEError extends Error {
     constructor(message) {
         super(message);
         this.name = "Boolean Unification Failure";
-    }
-}
-
-/**
- * A custom exception used to signal failure of syntactic matching special case.
- */
-class SyntacticMatchError extends Error {
-    constructor(message) {
-        super(message);
-        this.name = "Syntactic Match Failure";
     }
 }

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -17,6 +17,25 @@ import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar,
 import {applySubst} from "./Substitution";
 
 /**
+ * Enumeration to select the available methods for unification
+ */
+export const METHOD = Object.freeze({
+    SVE: "sve",
+    Lowenheim: "lowenheim"
+})
+
+/**
+ * Given a value from the METHOD enumeration, returns the associated Boolean unification function.
+ */
+export function getUnifyMethod(methodName) {
+    switch (methodName) {
+        case METHOD.SVE: return boolUnify;
+        case METHOD.Lowenheim: return lowenheimUnify;
+        default: throw new Error(`Invalid Boolean unification method ${methodName}`)
+    }
+}
+
+/**
  * Returns a substitution that unifies f1 and f2 (if it exists).
  */
 export function boolUnify(f1, f2) {

--- a/src/BoolUnification.js
+++ b/src/BoolUnification.js
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar, showBool, TRUE, isVar, truthTable, minBool} from "./Bools.js";
+import {FALSE, boolFreeVars, isBool, isFalse, isTrue, mkAnd, mkNot, mkOr, mkVar, showBool, TRUE, isVar, truthTable, minBool, mkXor} from "./Bools.js";
 import {applySubst} from "./Substitution";
 
 /**
@@ -47,7 +47,7 @@ export function boolUnify(f1, f2) {
     }
 
     // The boolean expression we want to show is 0.
-    let query = mkOr(mkAnd(f1, mkNot(f2)), mkAnd(mkNot(f1), f2))
+    let query = mkXor(f1, f2)
 
     // The free variables in the query.
     let fvs = boolFreeVars(query)
@@ -136,6 +136,12 @@ function satisfiable(f) {
     }
 }
 
+/**
+ * Computes a most-general unifier of a Boolean equation using the Lowenheim method.
+ * Lowenheim's method first computes any valid unifier, then applies a Boolean expression
+ * equivalent of an if-else statement to each element in that unifier to yield a most-general
+ * unifier.
+ */
 export function lowenheimUnify(f1, f2) {
     if (f1 === undefined || !isBool(f1)) {
         throw new Error(`Illegal argument 'x': ${f1}.`)
@@ -145,27 +151,36 @@ export function lowenheimUnify(f1, f2) {
     }
 
     // The boolean expression we want to show is 0.
-    let query = mkOr(mkAnd(f1, mkNot(f2)), mkAnd(mkNot(f1), f2))
+    let query = mkXor(f1, f2)
     // The free variables in the query.
     let fvs = boolFreeVars(query)
 
-    let initUnifiers = initialUnifiers(query, fvs)
+    // find valid ground unifiers
+    let initUnifiers = groundUnifiers(query, fvs)
+    // convert ground unifiers to most general unifiers
     let mgus = initUnifiers.map(u => mguFromUnifier(u, query))
 
     if (mgus.length === 0) {
         return {status: "failure", reason: `Cannot unify: ${showBool(f1)} and ${showBool(f2)}`}
     }
 
+    // show all most-general unifiers computed in the console
     for (const [ind, mgu] of mgus.entries()) {
         for (const [key, val] of Object.entries(mgu)) {
             console.log(`  ${key} --> ${showBool(minBool(val, true))}`)
         }
     }
 
+    // return the last computed most-general unifier, arbitrarily
     return {status: "success", subst: mgus[mgus.length -1]}
 }
 
-function initialUnifiers(query, fvs) {
+/**
+ * Given a Boolean equation, and the list of it's free variables, compute
+ * the set of ground unifiers; i.e. the set of unifiers where each variable
+ * maps to `true` or `false`, such that resulting truth row equals `false`.
+ */
+function groundUnifiers(query, fvs) {
     let tt = truthTable(query, fvs)
     let falseRows = tt.filter(t => isFalse(t[t.length - 1]))
     let unifiers = falseRows.map(row => {
@@ -178,6 +193,11 @@ function initialUnifiers(query, fvs) {
     return unifiers
 }
 
+/**
+ * Apply Lowenheim's insight to each element of a unifier in order to
+ * make the unifier both most-general and reproductive. Returns a new unifier
+ * with the modified elements.
+ */
 function mguFromUnifier(unifier, term) {
     let mgu = {};
     for (const [key, val] of Object.entries(unifier)) {
@@ -186,11 +206,31 @@ function mguFromUnifier(unifier, term) {
     return mgu;
 }
 
+/**
+ * Given a variable `substKey` from a substitution and it's corresponding value, as well as
+ * the original equation `term` we're unifying for, this function returns the corresponding
+ * Boolean formula that makes the substitution value for the variable a most-general,
+ * reproductive substitution.
+ * 
+ * Lowenheim's insight:
+ * - given `eqn`, the original equation we want to unify
+ * - given `subst(x)`, the unifier we want to generalize
+ * 
+ * If `subst(x)` is indeed a unifier of `eqn`, then the following step computes a new
+ * value for `x` in the MGU:
+ * ```
+ * mgu(x) = ((eqn xor true) and x) xor (eqn and subst(x))
+ * ```
+ * 
+ * This works because in a Boolean ring, `(b1 xor true) and b2 xor b1 and b3` behaves
+ * like a conditional, i.e. `if b1 then b2 else b3`. This reduces Boolean unification
+ * to equation solving in a Boolean ring.
+ */
 function lowenheimGen(substKey, substValue, term) {
-    let termXorTrue = mkOr(mkAnd(term, mkNot(TRUE)), mkAnd(mkNot(term), TRUE))
+    let termXorTrue = mkXor(term, TRUE)
     let andKey = mkAnd(termXorTrue, mkVar(substKey))
     let termAndSubst = mkAnd(term, substValue)
-    return mkOr(mkAnd(andKey, mkNot(termAndSubst)), mkAnd(mkNot(andKey), termAndSubst))
+    return mkXor(andKey, termAndSubst)
 }
 
 /**

--- a/src/Bools.js
+++ b/src/Bools.js
@@ -153,7 +153,7 @@ export function mkOr(f1, f2) {
 /**
  * Returns `true` if the Boolean formulas `f1` and `f2` are *syntactically* equal.
  */
-export function isSyntacticEq(f1, f2) {
+function isSyntacticEq(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
     if (f2 === undefined || !isBool(f2)) throw new Error(`Illegal argument 'f2': ${f2}.`)
 

--- a/src/Bools.js
+++ b/src/Bools.js
@@ -153,7 +153,7 @@ export function mkOr(f1, f2) {
 /**
  * Returns `true` if the Boolean formulas `f1` and `f2` are *syntactically* equal.
  */
-function isSyntacticEq(f1, f2) {
+export function isSyntacticEq(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
     if (f2 === undefined || !isBool(f2)) throw new Error(`Illegal argument 'f2': ${f2}.`)
 

--- a/src/Bools.js
+++ b/src/Bools.js
@@ -129,7 +129,7 @@ export function mkAnd(f1, f2) {
 }
 
 /**
- * Returns the disjunction of the two formulas `f1` and `f2`.
+ * Returns the inclusive disjunction of the two formulas `f1` and `f2`.
  */
 export function mkOr(f1, f2) {
     if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
@@ -148,6 +148,17 @@ export function mkOr(f1, f2) {
     }
 
     return {type: 'OR', f1: f1, f2: f2}
+}
+
+/**
+ * Returns the exclusive disjunction of the two formulas `f1` and `f2`, as a construction
+ * of `mkOr`, `mkAnd`, and `mkNot`.
+ */
+export function mkXor(f1, f2) {
+    if (f1 === undefined || !isBool(f1)) throw new Error(`Illegal argument 'f1': ${f1}.`)
+    if (f2 === undefined || !isBool(f2)) throw new Error(`Illegal argument 'f2': ${f2}.`)
+
+    return mkOr(mkAnd(f1, mkNot(f2)), mkAnd(mkNot(f1), f2))
 }
 
 /**

--- a/src/TermUnification.js
+++ b/src/TermUnification.js
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 import {isBool, minBool, showBool} from "./Bools";
-import {boolUnify} from "./BoolUnification";
+import {boolUnify, lowenheimUnify} from "./BoolUnification";
 import {applySubst, mergeSubst} from "./Substitution";
 import {isConstructor, mkConstructor, showTerm} from "./Terms";
 
@@ -30,7 +30,7 @@ export function unifyTerm(t1, t2) {
     }
 
     if (isBool(t1) && isBool(t2)) {
-        return boolUnify(t1, t2)
+        return lowenheimUnify(t1, t2)//boolUnify(t1, t2)
     } else if (isConstructor(t1) && isConstructor(t2)) {
         if (t1.name === t2.name) {
             return unifyTermLists(t1.ts, t2.ts)

--- a/src/TermUnification.js
+++ b/src/TermUnification.js
@@ -14,14 +14,13 @@
  *  limitations under the License.
  */
 import {isBool, minBool, showBool} from "./Bools";
-import {boolUnify, lowenheimUnify} from "./BoolUnification";
 import {applySubst, mergeSubst} from "./Substitution";
 import {isConstructor, mkConstructor, showTerm} from "./Terms";
 
 /**
  * Returns a substitution that unifies x and y (if it exists).
  */
-export function unifyTerm(t1, t2) {
+export function unifyTerm(t1, t2, unifyBool) {
     if (t1 === undefined) {
         throw new Error(`Illegal argument 't1': ${t1}.`)
     }
@@ -30,10 +29,10 @@ export function unifyTerm(t1, t2) {
     }
 
     if (isBool(t1) && isBool(t2)) {
-        return lowenheimUnify(t1, t2)//boolUnify(t1, t2)
+        return unifyBool(t1, t2)
     } else if (isConstructor(t1) && isConstructor(t2)) {
         if (t1.name === t2.name) {
-            return unifyTermLists(t1.ts, t2.ts)
+            return unifyTermLists(t1.ts, t2.ts, unifyBool)
         } else {
             return {status: "failure", reason: `Mismatched constructors: ${t1.name} and ${t2.name}.`}
         }
@@ -55,7 +54,7 @@ export function unifyTerm(t1, t2) {
 /**
  * Returns a substitution that unifies the two term lists `l1` and `l2`.
  */
-function unifyTermLists(l1, l2) {
+function unifyTermLists(l1, l2, unifyBool) {
     if (!Array.isArray(l1)) {
         throw new Error(`Illegal argument l1: ${l1}`)
     }
@@ -76,7 +75,7 @@ function unifyTermLists(l1, l2) {
         let [y, ...ys] = l2
 
         // Unify x and y.
-        let result = unifyTerm(x, y)
+        let result = unifyTerm(x, y, unifyBool)
         if (result.status !== "success") {
             // Failed. Return immediately.
             return result
@@ -89,7 +88,7 @@ function unifyTermLists(l1, l2) {
             let ys1 = ys.map(t => applySubst(subst, t))
 
             // Recursive unify xs1 and ys1.
-            let result1 = unifyTermLists(xs1, ys1)
+            let result1 = unifyTermLists(xs1, ys1, unifyBool)
 
             if (result1.status !== "success") {
                 // Failed. Return.

--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -62,6 +62,14 @@ class FormInput extends Component {
         }
     }
 
+    notifyLowenheim() {
+        this.props.toggleLowenheim(() => {
+            if (this.state.lhsParsed.valid && this.state.rhsParsed.valid) {
+                this.props.notifySolve(this.state.lhsParsed.value, this.state.rhsParsed.value)
+            }
+        })
+    }
+
     simplifyFormulas() {
         function simplify(f) {
             return showBool(minBool(f, true))
@@ -81,6 +89,7 @@ class FormInput extends Component {
         let minimizeSubFormulas = this.props.minimizeSubFormulas
         let truthTable = this.props.truthTable
         let parenthesize = this.props.parenthesize
+        let lowenheim = this.props.lowenheim
 
         let toggleReformat = this.props.toggleReformat
         let toggleLogicSymbols = this.props.toggleLogicSymbols
@@ -150,6 +159,13 @@ class FormInput extends Component {
                                              label="Fully parenthesize"
                                              checked={parenthesize}
                                              onChange={toggleParenthesize}
+                                             inline
+                                />
+
+                                <CustomInput id="lowenheim" type="checkbox"
+                                             label="Use Lowenheim"
+                                             checked={lowenheim}
+                                             onChange={this.notifyLowenheim.bind(this)}
                                              inline
                                 />
                             </Row>

--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -17,6 +17,7 @@ import React, {Component} from "react";
 import {Card, CardBody, CardHeader, Col, CustomInput, Form, FormFeedback, FormGroup, Input, Row} from "reactstrap";
 import {parse} from "../Parser";
 import {minBool, showBool} from "../Bools";
+import { METHOD } from "../BoolUnification";
 
 class FormInput extends Component {
 
@@ -62,8 +63,9 @@ class FormInput extends Component {
         }
     }
 
-    notifyLowenheim() {
-        this.props.toggleLowenheim(() => {
+    notifyChangeMethod(e) {
+        console.log(e.target.value)
+        this.props.changeMethod(e.target.value, () => {
             if (this.state.lhsParsed.valid && this.state.rhsParsed.valid) {
                 this.props.notifySolve(this.state.lhsParsed.value, this.state.rhsParsed.value)
             }
@@ -89,7 +91,7 @@ class FormInput extends Component {
         let minimizeSubFormulas = this.props.minimizeSubFormulas
         let truthTable = this.props.truthTable
         let parenthesize = this.props.parenthesize
-        let lowenheim = this.props.lowenheim
+        let method = this.props.unifyMethod
 
         let toggleReformat = this.props.toggleReformat
         let toggleLogicSymbols = this.props.toggleLogicSymbols
@@ -97,6 +99,11 @@ class FormInput extends Component {
         let toggleMinimizeSubFormulas = this.props.toggleMinimizeSubFormulas
         let toggleTruthTable = this.props.toggleTruthTable
         let toggleParenthesize = this.props.toggleParenthesize
+
+        const methodOptions = [];
+        for (const [key, value] of Object.entries(METHOD)) {
+            methodOptions.push(<option value={value}>{key}</option>)
+        }
 
         return (
             <Row className="col-12">
@@ -162,12 +169,13 @@ class FormInput extends Component {
                                              inline
                                 />
 
-                                <CustomInput id="lowenheim" type="checkbox"
-                                             label="Use Lowenheim"
-                                             checked={lowenheim}
-                                             onChange={this.notifyLowenheim.bind(this)}
-                                             inline
-                                />
+                                <CustomInput id="method" type="select"
+                                             label="Method"
+                                             onChange={this.notifyChangeMethod.bind(this)}
+                                             value={method}
+                                >
+                                    {methodOptions}
+                                </CustomInput>
                             </Row>
                         </Form>
                     </CardBody>


### PR DESCRIPTION
Based on the method described in *Term Rewriting and All That*. The current implementation generates multiple MGUs and selects, arbitrarily, the last one in the generated list. No special cases implemented yet.

Refactored the `termUnify` function to take a Boolean unification function as a parameter, so the front-end could decide which method to use. This could allow for more than just SVE vs Lowenheim, but for now the choice is just a checkbox that can be toggled on and off for instant recomputation of the MGU using the specified method.